### PR TITLE
Allow to override the download url of the caddy archive

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,13 +9,15 @@
 #   Defaults to 0.9.3
 #
 class caddy (
-  $version            = $::caddy::params::version,
-  $manage_user        = true,
-  $manage_group       = true,
-  $user               = $::caddy::params::user,
-  $group              = $::caddy::params::group,
-  $install_method     = $::caddy::params::install_method,
-  $release_file_name  = $::caddy::params::release_file_name,
+  $version              = $::caddy::params::version,
+  $manage_user          = true,
+  $manage_group         = true,
+  $user                 = $::caddy::params::user,
+  $group                = $::caddy::params::group,
+  $install_method       = $::caddy::params::install_method,
+  $release_file_name    = $::caddy::params::release_file_name,
+  $archive_download_url = undef,
+  $bin_file_name        = $::caddy::params::bin_file_name,
 ) inherits caddy::params {
   if $install_method == 'source' and !defined(Class['golang']) {
     class { 'golang':
@@ -28,9 +30,9 @@ class caddy (
     'archive' => "${::caddy::params::install_path}",
   }
 
-  $bin_file_name = $install_method ? {
+  $real_bin_file_name = $install_method ? {
     'source'  => 'caddy',
-    'archive' => "${::caddy::params::bin_file_name}",
+    'archive' => $bin_file_name,
   }
 
   include caddy::install


### PR DESCRIPTION
This is needed when you want to install caddy with some add-on, as those are build-time plugins, you need to download a pre-built binary of caddy with the add-ons you want.

Needed for this PR: https://github.com/skyscrapers/puppet/pull/3559