### PR TITLE
Allow parameters with multiple occurrences

### DIFF
--- a/templates/etc/caddy/Caddyfile_server.erb
+++ b/templates/etc/caddy/Caddyfile_server.erb
@@ -4,7 +4,13 @@
     <%- if value.is_a?(Hash) -%>
   <%= key -%> {
       <%- value.each do |parameter_key, parameter_value| -%>
+        <%- if parameter_value.is_a?(Array) -%>
+          <%- parameter_value.each do |final_param_value| -%>
+    <%= parameter_key -%> <%= final_param_value %>
+          <%- end -%>
+        <%- else -%>
     <%= parameter_key -%> <%= parameter_value %>
+        <%- end -%>
       <%- end -%>
   }
     <%- else -%>


### PR DESCRIPTION
Some Caddy parameters can be declared multiple times, like the `header_downstream` parameter. With this change, you can specify such parameter values in puppet or hiera as an array.