### PR TITLE
Caddy upgrade

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,11 @@ class caddy (
   $user                 = $::caddy::params::user,
   $group                = $::caddy::params::group,
   $install_method       = $::caddy::params::install_method,
-  $release_file_name    = $::caddy::params::release_file_name,
+  $release_file_name    = versioncmp('0.9.99', $version) ? {
+    1 => 'caddy_linux_amd64.tar.gz',
+    default => "caddy_v${version}_linux_amd64.tar.gz"
+  },
+  $archive_file         = "/tmp/${release_file_name}",
   $archive_download_url = undef,
   $bin_file_name        = $::caddy::params::bin_file_name,
   $log_path             = $::caddy::params::log_path,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,15 +15,16 @@ class caddy (
   $user                 = $::caddy::params::user,
   $group                = $::caddy::params::group,
   $install_method       = $::caddy::params::install_method,
+  $archive_download_url = undef,
+  $log_path             = $::caddy::params::log_path,
+) inherits caddy::params {
+
   $release_file_name    = versioncmp('0.9.99', $version) ? {
     1 => 'caddy_linux_amd64.tar.gz',
     default => "caddy_v${version}_linux_amd64.tar.gz"
-  },
-  $archive_file         = "/tmp/${release_file_name}",
-  $archive_download_url = undef,
-  $bin_file_name        = $::caddy::params::bin_file_name,
-  $log_path             = $::caddy::params::log_path,
-) inherits caddy::params {
+  }
+  $archive_file         = "/tmp/${release_file_name}"
+
   if $install_method == 'source' and !defined(Class['golang']) {
     class { 'golang':
       repo_version => 'go1.7'
@@ -37,7 +38,10 @@ class caddy (
 
   $real_bin_file_name = $install_method ? {
     'source'  => 'caddy',
-    'archive' => $bin_file_name,
+    'archive' => versioncmp('0.9.99', $version)? {
+      1 => 'caddy_linux_amd64',
+      default => 'caddy'
+    },
   }
 
   include caddy::install

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,6 @@ class caddy::params {
   $version = '0.9.3'
   # TODO: support multiple architectures (386 and 64 bit)
   # TODO: support multiple os
-  $bin_file_name = 'caddy_linux_amd64'
   $install_path = '/opt/caddy'
   # TODO: support multiple service providers
   $service_name = 'caddy'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,11 +1,18 @@
 # == Class: caddy::params
 #
 class caddy::params {
+  include ::caddy
+
   $version = '0.9.3'
   # TODO: support multiple architectures (386 and 64 bit)
   # TODO: support multiple os
   $bin_file_name = 'caddy_linux_amd64'
-  $release_file_name = 'caddy_linux_amd64.tar.gz'
+  $release_file_name = versioncmp('0.9.99', $caddy::version) ? {
+    # 1 => 'caddy_linux_amd64.tar.gz',
+    # default => "caddy_v${version}_linux_amd64.tar.gz"
+    1 => "caddy_v${version}_linux_amd64.tar.gz",
+    default => 'caddy_linux_amd64.tar.gz'
+  }
   $install_path = '/opt/caddy'
   $archive_file = "/tmp/${release_file_name}"
   # TODO: support multiple service providers

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,20 +1,11 @@
 # == Class: caddy::params
 #
 class caddy::params {
-  include ::caddy
-
   $version = '0.9.3'
   # TODO: support multiple architectures (386 and 64 bit)
   # TODO: support multiple os
   $bin_file_name = 'caddy_linux_amd64'
-  $release_file_name = versioncmp('0.9.99', $caddy::version) ? {
-    # 1 => 'caddy_linux_amd64.tar.gz',
-    # default => "caddy_v${version}_linux_amd64.tar.gz"
-    1 => "caddy_v${version}_linux_amd64.tar.gz",
-    default => 'caddy_linux_amd64.tar.gz'
-  }
   $install_path = '/opt/caddy'
-  $archive_file = "/tmp/${release_file_name}"
   # TODO: support multiple service providers
   $service_name = 'caddy'
 


### PR DESCRIPTION
Support for versions 0.10.0 and upwards.

Tested locally on Vagrant so far.