### PR TITLE
fix exec ependency and linter warnings

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,18 +3,18 @@
 class caddy::config (
 ) {
   file { $::caddy::config_path:
-    ensure  => directory,
-    owner   => 'root',
-    group   => 'root',
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
   }
 
   # TODO: test config or make service fail when there's an error
   concat { $::caddy::caddyfile:
-    ensure  => present,
-    mode    => '0644',
-    owner   => 'root',
-    group   => 'root',
-    require => File[$::caddy::config_path],
+    ensure         => present,
+    mode           => '0644',
+    owner          => 'root',
+    group          => 'root',
+    require        => File[$::caddy::config_path],
     ensure_newline => true
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,9 +19,12 @@ class caddy (
   $log_path             = $::caddy::params::log_path,
 ) inherits caddy::params {
 
-  $release_file_name    = versioncmp('0.9.99', $version) ? {
-    1 => 'caddy_linux_amd64.tar.gz',
-    default => "caddy_v${version}_linux_amd64.tar.gz"
+  if versioncmp('0.9.99', $version) > 0 {
+    $archive_real_bin_file_name = 'caddy_linux_amd64'
+    $release_file_name          = 'caddy_linux_amd64.tar.gz'
+  } else {
+    $archive_real_bin_file_name = 'caddy'
+    $release_file_name          = "caddy_v${version}_linux_amd64.tar.gz"
   }
   $archive_file         = "/tmp/${release_file_name}"
 
@@ -38,10 +41,7 @@ class caddy (
 
   $real_bin_file_name = $install_method ? {
     'source'  => 'caddy',
-    'archive' => versioncmp('0.9.99', $version)? {
-      1 => 'caddy_linux_amd64',
-      default => 'caddy'
-    },
+    'archive' => $archive_real_bin_file_name
   }
 
   include caddy::install

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,9 +3,9 @@
 class caddy::install {
   if $::caddy::manage_user {
     user { $::caddy::user:
+      ensure  => present,
       comment => 'Caddy user',
       home    => '/var/www',
-      ensure  => present,
       shell   => '/usr/sbin/nologin',
       gid     => $::caddy::group,
     }
@@ -28,20 +28,20 @@ class caddy::install {
       }
 
       archive { $::caddy::archive_file:
-        ensure        => present,
-        extract       => true,
-        extract_path  => $::caddy::install_path,
-        source        => $::caddy::archive_download_url ? {
+        ensure       => present,
+        extract      => true,
+        extract_path => $::caddy::install_path,
+        source       => $::caddy::archive_download_url ? {
           undef   => "https://github.com/mholt/caddy/releases/download/v${::caddy::version}/${::caddy::release_file_name}",
           default => $::caddy::archive_download_url
         },
         # checksum      => '2ca09f0b36ca7d71b762e14ea2ff09d5eac57558',
         # checksum_type => 'sha1',
-        creates       => "${::caddy::install_path}/${::caddy::real_bin_file_name}",
-        cleanup       => true,
-        require       => File[$::caddy::install_path],
-        user          => 'root',
-        group         => 'root',
+        creates      => "${::caddy::install_path}/${::caddy::real_bin_file_name}",
+        cleanup      => true,
+        require      => File[$::caddy::install_path],
+        user         => 'root',
+        group        => 'root',
       }
 
       exec { 'root permission':
@@ -52,13 +52,13 @@ class caddy::install {
     }
     'source' : {
       $go_install_cmd = "${::golang::base_dir}/bin/go get github.com/mholt/caddy/caddy"
-      exec { "${go_install_cmd}":
+      exec { $go_install_cmd:
         environment => [
           "GOPATH=${::golang::workdir}",
           "GOROOT=${::golang::base_dir}"
         ],
-        creates => "${::caddy::install_path}/${::caddy::real_bin_file_name}",
-        require => Class['golang::install']
+        creates     => "${::caddy::install_path}/${::caddy::real_bin_file_name}",
+        require     => Class['golang::install']
       }
     }
   }
@@ -71,7 +71,7 @@ class caddy::install {
       owner   => 'root',
       group   => 'root',
       require => $::caddy::install_method ? {
-        'source' => Exec[$go_install_cmd],
+        'source'  => Exec[$go_install_cmd],
         'archive' => Archive[$::caddy::archive_file]
       }
     }
@@ -80,26 +80,29 @@ class caddy::install {
   # Create the folder where the log files end up in
   file { $::caddy::log_path:
     ensure => 'directory',
-    mode    => '0750',
-    owner => $::caddy::user,
-    group => $::caddy::group,
+    mode   => '0750',
+    owner  => $::caddy::user,
+    group  => $::caddy::group,
   }
 
   # Create the folder where the ssl certificates will be
   file { $::caddy::certificates_path:
-    ensure  => directory,
-    mode    => '0750',
-    owner   => $::caddy::user,
-    group   => $::caddy::group
+    ensure => directory,
+    mode   => '0750',
+    owner  => $::caddy::user,
+    group  => $::caddy::group
   }
 
   # Allow caddy web server to listen on privileged ports (< 1024)
-  exec { "setcap cap_net_bind_service=+ep ${::caddy::install_path}/${::caddy::real_bin_file_name}":
+  exec { 'setcap':
+    command = "setcap cap_net_bind_service=+ep ${::caddy::install_path}/${::caddy::real_bin_file_name}",
     path      => ['/sbin', '/usr/sbin', '/bin', '/usr/bin', ],
     subscribe => $::caddy::install_method ? {
-      'source' => Exec[$go_install_cmd],
+      'source'  => Exec[$go_install_cmd],
       'archive' => Archive[$::caddy::archive_file]
     },
     unless    => "getcap ${::caddy::install_path}/${::caddy::real_bin_file_name} | grep cap_net_bind_service+ep",
   }
+
+  Exec['root permission'] -> Exec['setcap']
 }


### PR DESCRIPTION
This should fix the `setcap` bug where it is not correctly set on the first run.

Additionally a lot of linter warnings are fixed