### PR TITLE
Log to stdout for journald to handle the logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,17 @@ In hiera data:
 ---
   caddy::servers:
     'www.caddy.com':
-      log: '/var/log/access.log'
+      log: 'stdout'
       gzip: ''
       'markdown /blog':
         css: '/blog.css'
         js: '/scripts.js'
 
 ```
+
+For setups managed by `systemd`, try to use `log stdout` and `errors stderr` as much as possible for the logs to end up in `journald`.
+With `journalctl` it is quite easy to search for specific log entries in a unified way.
+
+E.g. search for LetsEncrypt rate limiting messages in the last 5 days:
+
+`$ journalctl -u caddy -p err --since "5 days ago"`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,6 @@ class caddy (
   $group                = $::caddy::params::group,
   $install_method       = $::caddy::params::install_method,
   $archive_download_url = undef,
-  $log_path             = $::caddy::params::log_path,
 ) inherits caddy::params {
 
   if versioncmp('0.9.99', $version) > 0 {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -77,14 +77,6 @@ class caddy::install {
     }
   }
 
-  # Create the folder where the log files end up in
-  file { $::caddy::log_path:
-    ensure => 'directory',
-    mode   => '0750',
-    owner  => $::caddy::user,
-    group  => $::caddy::group,
-  }
-
   # Create the folder where the ssl certificates will be
   file { $::caddy::certificates_path:
     ensure => directory,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,6 @@ class caddy::params {
   $user = 'www-data'
   $group = 'www-data'
   $certificates_path = '/etc/ssl/caddy'
-  $log_path = '/var/log/caddy'
 
   # Allowed values: archive, source
   $install_method = 'archive'

--- a/templates/lib/systemd/system/caddy.service.erb
+++ b/templates/lib/systemd/system/caddy.service.erb
@@ -15,7 +15,7 @@ Group=<%= scope.lookupvar('caddy::group') %>
 Environment=HOME=<%= scope.lookupvar('caddy::certificates_path') %>
 
 ; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
-ExecStart=/usr/local/bin/caddy -log <%= scope.lookupvar('caddy::log_path') %>/server.log -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
+ExecStart=/usr/local/bin/caddy -log stdout -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
 ExecReload=/bin/kill -USR1 $MAINPID
 
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.


### PR DESCRIPTION
Will use `journalctl` query to search for the rate limiting errors.
