### PR TITLE
Update Caddy to 1.0.4

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,7 @@ class caddy::config (
 ) {
   file { $::caddy::config_path:
     ensure => directory,
+    mode   => '0755',
     owner  => 'root',
     group  => 'root',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class caddy (
   $manage_group         = true,
   $user                 = $::caddy::params::user,
   $group                = $::caddy::params::group,
+  $certificates_path    = $::caddy::params::certificates_path,
   $install_method       = $::caddy::params::install_method,
   $archive_download_url = undef,
 ) inherits caddy::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 #
 # version
 #   Release of the Caddy web server to install
-#   Defaults to 0.9.3
+#   Defaults to 1.0.4
 #
 class caddy (
   $version              = $::caddy::params::version,
@@ -35,7 +35,7 @@ class caddy (
 
   $install_path = $install_method ? {
     'source'  => "${::golang::workdir}bin",
-    'archive' => "${::caddy::params::install_path}",
+    'archive' => $::caddy::params::install_path,
   }
 
   $real_bin_file_name = $install_method ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 # == Class: caddy::params
 #
 class caddy::params {
-  $version = '0.9.3'
+  $version = '1.0.4'
   # TODO: support multiple architectures (386 and 64 bit)
   # TODO: support multiple os
   $install_path = '/opt/caddy'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,9 +17,9 @@ class caddy::service {
   }
 
   service { $::caddy::service_name:
-    ensure    => running,
-    enable    => true,
-    require   => File[$service_file]
+    ensure  => running,
+    enable  => true,
+    require => File[$service_file]
   }
 
   File[$service_file] ~> Exec['caddy-systemd-reload'] ~> Service[$::caddy::service_name]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-caddy",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "skyscrapers.eu",
   "summary": "Puppet module to setup Caddy web server",
   "license": "MIT",

--- a/templates/lib/systemd/system/caddy.service.erb
+++ b/templates/lib/systemd/system/caddy.service.erb
@@ -4,28 +4,38 @@ Documentation=https://caddyserver.com/docs
 After=network-online.target
 Wants=network-online.target systemd-networkd-wait-online.service
 
+; Do not allow the process to be restarted in a tight loop. If the
+; process fails to start, something critical needs to be fixed.
+StartLimitIntervalSec=14400
+StartLimitBurst=10
+
 [Service]
-Restart=on-failure
+Restart=on-abnormal
 
 ; User and group the process will run as.
 User=<%= scope.lookupvar('caddy::user') %>
 Group=<%= scope.lookupvar('caddy::group') %>
 
 ; Letsencrypt-issued certificates will be written to this directory.
-Environment=HOME=<%= scope.lookupvar('caddy::certificates_path') %>
+Environment=CADDYPATH=<%= scope.lookupvar('caddy::certificates_path') %>
 
 ; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
-ExecStart=/usr/local/bin/caddy -log stdout -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
+ExecStart=/usr/local/bin/caddy -log stdout -log-timestamps=false -agree=true -conf=/etc/caddy/Caddyfile -root=/var/tmp
 ExecReload=/bin/kill -USR1 $MAINPID
+
+; Use graceful shutdown with a reasonable timeout
+KillMode=mixed
+KillSignal=SIGQUIT
+TimeoutStopSec=5s
 
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.
 LimitNOFILE=1048576
 ; Unmodified caddy is not expected to use more than that.
-LimitNPROC=64
+LimitNPROC=512
 
 ; Use private /tmp and /var/tmp, which are discarded after caddy stops.
 PrivateTmp=true
-; Use a minimal /dev
+; Use a minimal /dev (May bring additional security if switched to 'true', but it may not work on Raspberry Pi's or other devices, so it has been disabled in this dist.)
 PrivateDevices=true
 ; Hide /home, /root, and /run/user. Nobody will steal your SSH-keys.
 ProtectHome=true
@@ -33,10 +43,11 @@ ProtectHome=true
 ProtectSystem=full
 ; … except /etc/ssl/caddy, because we want Letsencrypt-certificates there.
 ;   This merely retains r/w access rights, it does not add any new. Must still be writable on the host!
+ReadWritePaths=<%= scope.lookupvar('caddy::certificates_path') %>
 ReadWriteDirectories=<%= scope.lookupvar('caddy::certificates_path') %>
 
 ; The following additional security directives only work with systemd v229 or later.
-; They further retrict privileges that can be gained by caddy. Uncomment if you like.
+; They further restrict privileges that can be gained by caddy. Uncomment if you like.
 ; Note that you may have to add capabilities required by any plugins in use.
 ;CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 ;AmbientCapabilities=CAP_NET_BIND_SERVICE


### PR DESCRIPTION
- Update Caddy to latest stable release
- Update systemd service

This will allow the use of ACMEv2.

**Breaking change**: Existing installs should to set `caddy::certificates_path: '/etc/ssl/caddy/.caddy'`

As per https://github.com/skyscrapers/engineering/issues/329