### PR TITLE
Enable ambient capabilities

### DIFF
--- a/templates/lib/systemd/system/caddy.service.erb
+++ b/templates/lib/systemd/system/caddy.service.erb
@@ -50,7 +50,7 @@ ReadWriteDirectories=<%= scope.lookupvar('caddy::certificates_path') %>
 ; They further restrict privileges that can be gained by caddy. Uncomment if you like.
 ; Note that you may have to add capabilities required by any plugins in use.
 ;CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-;AmbientCapabilities=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 ;NoNewPrivileges=true
 
 [Install]


### PR DESCRIPTION
Needed for Ubuntu 18.04 upgrade, as non-root users are not allowed to bind to default ports anymore, resulting in crashing Caddy
Note that this change was also tested with Ubuntu 16.04 for backward compatibility and it's safe

Related issue: https://github.com/skyscrapers/surveyanyplace/issues/619